### PR TITLE
Other  Pool Management Constructs

### DIFF
--- a/src/main/scala/io/chrisdavenport/linebacker/DualContext.scala
+++ b/src/main/scala/io/chrisdavenport/linebacker/DualContext.scala
@@ -1,0 +1,43 @@
+package io.chrisdavenport.linebacker
+
+import cats._
+import cats.implicits._
+import cats.effect._
+import fs2.Stream
+import scala.concurrent.ExecutionContext
+
+trait DualContext[F[_]] {
+  def blockingContext: F[ExecutionContext]
+  def defaultContext: F[ExecutionContext]
+
+  def block[A](fa: F[A])(implicit F: Async[F]): F[A] =
+    for {
+      bEC <- blockingContext
+      dEC <- defaultContext
+      _ <- Async.shift(bEC)
+      aE <- fa.attempt
+      _ <- Async.shift(dEC)
+      a <- Applicative[F].pure(aE).rethrow
+    } yield a
+}
+
+object DualContext {
+  def apply[F[_]](implicit ev: DualContext[F]) = ev
+
+  def fromContexts[F[_]: Applicative](
+      default: ExecutionContext,
+      blocking: ExecutionContext): DualContext[F] =
+    new DualContext[F] {
+      override def blockingContext = Applicative[F].pure(blocking)
+      override def defaultContext = Applicative[F].pure(default)
+    }
+
+  def fromLinebacker[F[_]: Sync](implicit EC: ExecutionContext): Stream[F, DualContext[F]] =
+    for {
+      lb <- Linebacker.stream[F]
+    } yield
+      new DualContext[F] {
+        override def blockingContext = Applicative[F].pure(lb.blockingPool)
+        override def defaultContext = Applicative[F].pure(EC)
+      }
+}

--- a/src/main/scala/io/chrisdavenport/linebacker/Quarterback.scala
+++ b/src/main/scala/io/chrisdavenport/linebacker/Quarterback.scala
@@ -1,0 +1,26 @@
+package io.chrisdavenport.linebacker
+
+import cats._
+import cats.effect.Async
+import cats.implicits._
+import scala.concurrent.ExecutionContext
+
+/**
+ * This is the thread pool manager.
+ * Select ExecutionContexts whenever you would like.
+ * Execute specific actions on specific threadpools.
+ * Options relevant to a decision are available to you.
+ *
+ */
+trait Quarterback[F[_], K] {
+  val select: K => ExecutionContext
+  def pass[A](fa: F[A], to: K)(implicit F: Async[F]): F[A] =
+    Async.shift(select(to)) *> fa
+  def fleaFlicker[A](fa: F[A], initial: K, end: K)(implicit F: Async[F]): F[A] =
+    for {
+      _ <- Async.shift(select(initial))
+      aE <- fa.attempt
+      _ <- Async.shift(select(end))
+      a <- Applicative[F].pure(aE).rethrow
+    } yield a
+}


### PR DESCRIPTION
Quarterback - Implements a total function `K => ExecutionContext` which allows your to translate back and forth on some other type than references to execution contexts.

DualContext - Takes the important information in the constructor, so that shifting occurs within the knowns rather than at the call site.