### PR TITLE
Add blockTimer and rename to blockShift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: scala
 
 scala:
-  - 2.12.4
+  - 2.12.6
   - 2.11.12
 
 jdk:
@@ -24,7 +24,7 @@ script:
 
 after_success:
 - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "ChristopherDavenport/linebacker" && sbt ++$TRAVIS_SCALA_VERSION publish
-- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "ChristopherDavenport/linebacker" && test $TRAVIS_SCALA_VERSION == "2.12.4" && sbt microsite/publishMicrosite
+- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "ChristopherDavenport/linebacker" && test $TRAVIS_SCALA_VERSION == "2.12.6" && sbt microsite/publishMicrosite
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ object ThreadNameExample {
     .map(Linebacker.fromExecutorService[IO](_)) // Create Linebacker From Executor
     .flatMap { implicit linebacker => // Raise Implicitly
       Stream.eval(
-        Linebacker[IO].block(getThread) // Block On Linebacker Pool Not Global
+        Linebacker[IO].blockShift(getThread) // Block On Linebacker Pool Not Global
       ) ++
       Stream.eval(getThread) // Running On Global
     }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ First some imports
 
 ```tut:silent
 import scala.concurrent.ExecutionContext.Implicits.global
-import fs2.Stream
 import cats.effect._
 import cats.implicits._
 import io.chrisdavenport.linebacker.Linebacker

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Creating And Evaluating Pool Behavior
 ```tut
 val getThread = IO(Thread.currentThread().getName)
 
-Executors.unbound[IO] // Create Executor
+val checkRun = {
+  Executors.unbound[IO] // Create Executor
     .map(Linebacker.fromExecutorService[IO](_)) // Create Linebacker From Executor
     .use{ implicit linebacker => // Raise Implicitly
       Linebacker[IO].blockEc(getThread) // Block On Linebacker Pool Not Global
@@ -36,8 +37,9 @@ Executors.unbound[IO] // Create Executor
       getThread // Running On Global
         .flatMap(threadName => IO(println(threadName)))
     }
+}
 
-ThreadNameExample.checkRun.unsafeRunSync
+checkRun.unsafeRunSync
 ```
 
 Dual Contexts Are Also Very Useful

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ val getThread = IO(Thread.currentThread().getName)
 Executors.unbound[IO] // Create Executor
     .map(Linebacker.fromExecutorService[IO](_)) // Create Linebacker From Executor
     .use{ implicit linebacker => // Raise Implicitly
-      Linebacker[IO].blockShift(getThread) // Block On Linebacker Pool Not Global
+      Linebacker[IO].blockEc(getThread) // Block On Linebacker Pool Not Global
         .flatMap(threadName => IO(println(threadName))) >>
       getThread // Running On Global
         .flatMap(threadName => IO(println(threadName)))

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,7 @@ lazy val commonSettings = Seq(
   scalafmtOnCompile := true,
   scalafmtTestOnCompile := true,
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-effect" % "0.10.1",
-    "co.fs2"        %% "fs2-core"    % "0.10.4",
+    "org.typelevel" %% "cats-effect" % "1.0.0-RC2-d7181dc",
     "org.specs2"    %% "specs2-core" % "4.2.0" % Test
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -28,13 +28,13 @@ lazy val commonSettings = Seq(
   organization := "io.chrisdavenport",
   scalaVersion := "2.12.6",
   crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
-  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.6" cross CrossVersion.binary),
+  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.7" cross CrossVersion.binary),
   scalafmtOnCompile := true,
   scalafmtTestOnCompile := true,
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats-effect" % "0.10.1",
-    "co.fs2"        %% "fs2-core"    % "0.10.3",
-    "org.specs2"    %% "specs2-core" % "4.0.3" % Test
+    "co.fs2"        %% "fs2-core"    % "0.10.4",
+    "org.specs2"    %% "specs2-core" % "4.2.0" % Test
   )
 )
 

--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/DualContext.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/DualContext.scala
@@ -10,7 +10,7 @@ trait DualContext[F[_]] {
   def defaultContext: ExecutionContext
 
   def block[A](fa: F[A])(implicit F: Async[F]): F[A] =
-    F.bracket(Async.shift[F](blockingContext))(_ => fa)(_ => Async.shift[F](defaultContext))
+    dualShift(blockingContext, defaultContext, fa)
 }
 
 object DualContext {

--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
@@ -11,6 +11,7 @@ trait Linebacker[F[_]] {
   def blockingPool: ExecutionContext
 
   // TODO: REMOVE 0.2
+  @deprecated("0.2.0", "Use blockShift instead.")
   final def block[A](fa: F[A])(implicit F: Async[F], ec: ExecutionContext): F[A] =
     blockShift(fa)(F, ec)
 

--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
@@ -13,7 +13,7 @@ trait Linebacker[F[_]] {
    * Then shifts back to the given implicit execution context
    * after the Async `F[A]` is evaluated.
    */
-  final def blockShift[A](fa: F[A])(implicit F: Async[F], ec: ExecutionContext): F[A] =
+  final def blockEc[A](fa: F[A])(implicit F: Async[F], ec: ExecutionContext): F[A] =
     dualShift(blockingContext, ec, fa)
 
   /**

--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
@@ -2,7 +2,7 @@ package io.chrisdavenport.linebacker
 
 import cats._
 import cats.implicits._
-import cats.effect.Async
+import cats.effect._
 import java.util.concurrent.ExecutorService
 import scala.concurrent.ExecutionContext
 
@@ -10,16 +10,32 @@ trait Linebacker[F[_]] {
 
   def blockingPool: ExecutionContext
 
+  // TODO: REMOVE 0.2
+  final def block[A](fa: F[A])(implicit F: Async[F], ec: ExecutionContext): F[A] =
+    blockShift(fa)(F, ec)
+
   /**
    * Attempts to Run the Given `F[A]` on the blocking pool.
    * Then shifts back to the given implicit execution context
    * after the Async `F[A]` is evaluated.
    */
-  final def block[A](fa: F[A])(implicit F: Async[F], ec: ExecutionContext): F[A] =
+  final def blockShift[A](fa: F[A])(implicit F: Async[F], ec: ExecutionContext): F[A] =
     for {
       _ <- Async.shift(blockingPool)
       eA <- fa.attempt
       _ <- Async.shift(ec)
+      a <- Applicative[F].pure(eA).rethrow
+    } yield a
+
+  /**
+   * Attempts to Run the Given `F[A]` on the blocking pool.
+   * Then shifts back to the F for the timer.
+   */
+  final def blockTimer[A](fa: F[A])(implicit F: Async[F], timer: Timer[F]): F[A] =
+    for {
+      _ <- Async.shift(blockingPool)
+      eA <- fa.attempt
+      _ <- timer.shift
       a <- Applicative[F].pure(eA).rethrow
     } yield a
 }

--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
@@ -8,14 +8,6 @@ trait Linebacker[F[_]] {
 
   def blockingContext: ExecutionContext
 
-  @deprecated("0.2.0", "Use blockingContext instead.")
-  private[linebacker] def blockingPool: ExecutionContext = blockingContext
-
-  @deprecated("0.2.0", "Use blockShift instead.")
-  final private[linebacker] def block[A](
-      fa: F[A])(implicit F: Async[F], ec: ExecutionContext): F[A] =
-    blockShift(fa)(F, ec)
-
   /**
    * Attempts to Run the Given `F[A]` on the blocking pool.
    * Then shifts back to the given implicit execution context

--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/Linebacker.scala
@@ -22,7 +22,7 @@ trait Linebacker[F[_]] {
    * after the Async `F[A]` is evaluated.
    */
   final def blockShift[A](fa: F[A])(implicit F: Async[F], ec: ExecutionContext): F[A] =
-    F.bracket(Async.shift[F](blockingContext))(_ => fa)(_ => Async.shift[F](ec))
+    dualShift(blockingContext, ec, fa)
 
   /**
    * Attempts to Run the Given `F[A]` on the blocking pool.

--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/Quarterback.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/Quarterback.scala
@@ -23,7 +23,7 @@ trait Quarterback[F[_], K] {
     for {
       iEC <- select(initial)
       endEC <- select(end)
-      a <- Async[F].bracket(Async.shift[F](iEC))(_ => fa)(_ => Async.shift(endEC))
+      a <- dualShift(iEC, endEC, fa)
     } yield a
 }
 object Quarterback {

--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/Quarterback.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/Quarterback.scala
@@ -1,6 +1,5 @@
 package io.chrisdavenport.linebacker
 
-import cats._
 import cats.effect.Async
 import cats.implicits._
 import scala.concurrent.ExecutionContext
@@ -23,11 +22,8 @@ trait Quarterback[F[_], K] {
   def fleaFlicker[A](fa: F[A], initial: K, end: K)(implicit F: Async[F]): F[A] =
     for {
       iEC <- select(initial)
-      _ <- Async.shift(iEC)
-      aE <- fa.attempt
-      eEC <- select(end)
-      _ <- Async.shift(eEC)
-      a <- Applicative[F].pure(aE).rethrow
+      endEC <- select(end)
+      a <- Async[F].bracket(Async.shift[F](iEC))(_ => fa)(_ => Async.shift(endEC))
     } yield a
 }
 object Quarterback {

--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/package.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/package.scala
@@ -1,0 +1,13 @@
+package io.chrisdavenport
+
+import cats.effect.Async
+import scala.concurrent.ExecutionContext
+
+package object linebacker {
+  private[linebacker] def dualShift[F[_]: Async, A](
+      initialEc: ExecutionContext,
+      endEc: ExecutionContext,
+      fa: F[A]) =
+    Async[F].bracket(Async.shift[F](initialEc))(_ => fa)(_ => Async.shift[F](endEc))
+
+}

--- a/linebacker/src/test/scala/io/chrisdavenport/linebacker/LinebackerSpec.scala
+++ b/linebacker/src/test/scala/io/chrisdavenport/linebacker/LinebackerSpec.scala
@@ -21,7 +21,7 @@ class LinebackerSpec extends Spec {
       .map(Linebacker.fromExecutorService[IO])
       .use { implicit linebacker =>
         import scala.concurrent.ExecutionContext.Implicits.global
-        Linebacker[IO].blockShift(IO(Thread.currentThread().getName))
+        Linebacker[IO].blockEc(IO(Thread.currentThread().getName))
       }
 
     testRun.unsafeRunSync must_=== "linebacker-thread-0"
@@ -43,7 +43,7 @@ class LinebackerSpec extends Spec {
 
     implicit val linebacker = Linebacker.fromExecutionContext[IO](ec)
 
-    val testRun = Linebacker[IO].blockShift(IO.unit) *>
+    val testRun = Linebacker[IO].blockEc(IO.unit) *>
       IO(Thread.currentThread().getName) <*
       IO(executor.shutdownNow)
 

--- a/linebacker/src/test/scala/io/chrisdavenport/linebacker/LinebackerSpec.scala
+++ b/linebacker/src/test/scala/io/chrisdavenport/linebacker/LinebackerSpec.scala
@@ -24,7 +24,7 @@ class LinebackerSpec extends Spec {
         Linebacker[IO].blockShift(IO(Thread.currentThread().getName))
       }
 
-    testRun.unsafeRunSync must_== Some("linebacker-thread-0")
+    testRun.unsafeRunSync must_=== "linebacker-thread-0"
   }
 
   def runsOffLinebackerAfterwards = {
@@ -47,6 +47,6 @@ class LinebackerSpec extends Spec {
       IO(Thread.currentThread().getName) <*
       IO(executor.shutdownNow)
 
-    testRun.unsafeRunSync must_== Some("test-ec-1")
+    testRun.unsafeRunSync must_=== "test-ec-1"
   }
 }

--- a/linebacker/src/test/scala/io/chrisdavenport/linebacker/LinebackerSpec.scala
+++ b/linebacker/src/test/scala/io/chrisdavenport/linebacker/LinebackerSpec.scala
@@ -22,7 +22,7 @@ class LinebackerSpec extends Spec {
       .flatMap { implicit linebacker =>
         import scala.concurrent.ExecutionContext.Implicits.global
         Stream.eval(
-          Linebacker[IO].block(IO(Thread.currentThread().getName))
+          Linebacker[IO].blockShift(IO(Thread.currentThread().getName))
         )
       }
       .compile
@@ -48,7 +48,7 @@ class LinebackerSpec extends Spec {
 
     Stream
       .eval(
-        Linebacker[IO].block(IO.unit) *>
+        Linebacker[IO].blockShift(IO.unit) *>
           IO(Thread.currentThread().getName)
           <* IO(executor.shutdownNow)
       )

--- a/linebacker/src/test/scala/io/chrisdavenport/linebacker/LinebackerSpec.scala
+++ b/linebacker/src/test/scala/io/chrisdavenport/linebacker/LinebackerSpec.scala
@@ -1,9 +1,8 @@
 package io.chrisdavenport.linebacker
 
 import org.specs2._
-import cats.effect.IO
+import cats.effect._
 import cats.implicits._
-import fs2.Stream
 import java.lang.Thread
 import scala.concurrent.ExecutionContext
 import java.util.concurrent.atomic.AtomicLong
@@ -17,17 +16,15 @@ class LinebackerSpec extends Spec {
   """
 
   def runsOnLinebacker = {
-    E.unbound[IO]
+    val testRun = E
+      .unbound[IO]
       .map(Linebacker.fromExecutorService[IO])
-      .flatMap { implicit linebacker =>
+      .use { implicit linebacker =>
         import scala.concurrent.ExecutionContext.Implicits.global
-        Stream.eval(
-          Linebacker[IO].blockShift(IO(Thread.currentThread().getName))
-        )
+        Linebacker[IO].blockShift(IO(Thread.currentThread().getName))
       }
-      .compile
-      .last
-      .unsafeRunSync must_== Some("linebacker-thread-0")
+
+    testRun.unsafeRunSync must_== Some("linebacker-thread-0")
   }
 
   def runsOffLinebackerAfterwards = {
@@ -46,14 +43,10 @@ class LinebackerSpec extends Spec {
 
     implicit val linebacker = Linebacker.fromExecutionContext[IO](ec)
 
-    Stream
-      .eval(
-        Linebacker[IO].blockShift(IO.unit) *>
-          IO(Thread.currentThread().getName)
-          <* IO(executor.shutdownNow)
-      )
-      .compile
-      .last
-      .unsafeRunSync must_== Some("test-ec-1")
+    val testRun = Linebacker[IO].blockShift(IO.unit) *>
+      IO(Thread.currentThread().getName) <*
+      IO(executor.shutdownNow)
+
+    testRun.unsafeRunSync must_== Some("test-ec-1")
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.1.6

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1-SNAPSHOT"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
This updates dependencies and add `blockTimer` which blocks and returns to an implicit timer and renames to `blockShift` to be used generally.