### PR TITLE
Dual Context Extends Linebacker

### DIFF
--- a/linebacker/src/main/scala/io/chrisdavenport/linebacker/DualContext.scala
+++ b/linebacker/src/main/scala/io/chrisdavenport/linebacker/DualContext.scala
@@ -5,7 +5,7 @@ import cats.effect._
 import java.util.concurrent.ExecutorService
 import scala.concurrent.ExecutionContext
 
-trait DualContext[F[_]] {
+trait DualContext[F[_]] extends Linebacker[F] {
   def blockingContext: ExecutionContext
   def defaultContext: ExecutionContext
 


### PR DESCRIPTION
I think this was an oversight before. Now block, uses everything internally but preserves `blockEc` and `blockTimer` from `Linebacker` and means either can be passed to methods that ask for a `Linebacker`